### PR TITLE
Add moderation notes

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -6,6 +6,7 @@ import Command from "../struct/Command"
 import Roles from "../util/roles"
 import ActionLog, { Action } from "../entities/ActionLog"
 import TimedPunishment from "../entities/TimedPunishment"
+import ModerationNote from "../entities/ModerationNote"
 import { FindManyOptions, Not, IsNull } from "typeorm"
 
 export default new Command({
@@ -76,6 +77,9 @@ export default new Command({
             }
         }
 
-        message.channel.sendSuccess(embed)
+        const notes = await ModerationNote.findOne({ where: { member: user.id } })
+        if (notes) embed.fields.push({ name: "Notes", value: notes.body, inline: true })
+
+        await message.channel.sendSuccess(embed)
     }
 })

--- a/src/commands/notes.ts
+++ b/src/commands/notes.ts
@@ -1,0 +1,112 @@
+import Client from "../struct/Client"
+import Message from "../struct/discord/Message"
+import Args from "../struct/Args"
+import Command from "../struct/Command"
+import Roles from "../util/roles"
+import ModerationNote from "../entities/ModerationNote"
+import formatUTCDate from "../util/formatUTCDate"
+
+export default new Command({
+    name: "notes",
+    aliases: ["note", "modnotes", "modnote"],
+    description: "Read and manage moderation notes.",
+    permission: [Roles.HELPER, Roles.MODERATOR, Roles.MANAGER],
+    usage: "<member> [body]",
+    subcommands: [
+        {
+            name: "add",
+            description: "Add (or append to) the notes for a member.",
+            usage: "<member> <body>"
+        },
+        {
+            name: "edit",
+            description: "Edit the notes for a member (overwriting the existing ones).",
+            usage: "<member> <body>"
+        },
+        {
+            name: "clear",
+            description: "Delete the notes for a member.",
+            usage: "<member>"
+        }
+    ],
+    async run(this: Command, client: Client, message: Message, args: Args) {
+        const subcommand = args.consumeIf(["add", "edit", "clear"])
+        const user = await args.consumeUser()
+        if (!user)
+            return message.channel.sendError(
+                user === undefined
+                    ? "You must provide a user!"
+                    : "Couldn't find that user."
+            )
+        const body = args.consumeRest()
+        if (subcommand && subcommand !== "clear") {
+            if (!body)
+                return message.channel.sendError("You must specify a new note body!")
+            if (body.length > 1024)
+                return message.channel.sendError(
+                    "That note is too long! (max. 1024 characters)."
+                )
+        }
+
+        const note = await ModerationNote.findOne({ where: { member: user.id } })
+
+        if (!subcommand && !body) {
+            const embed = {
+                thumbnail: {
+                    url: user.displayAvatarURL({ size: 64, format: "png", dynamic: true })
+                },
+                description: note
+                    ? `Here are ${user}'s moderation notes (you can also read them with \`${client.config.prefix}check @${user.tag}\`):\n\n${note.body}\n\u200B`
+                    : `✨ No moderation notes found for ${user} (${user.tag}).`,
+                fields: []
+            }
+            if (note)
+                embed.fields.push(
+                    {
+                        name: "Updated by",
+                        value: note.updaters.map(id => `<@${id}>`).join(", "),
+                        inline: true
+                    },
+                    {
+                        name: "Last updated",
+                        value: formatUTCDate(note.updatedAt),
+                        inline: true
+                    }
+                )
+            await message.channel.sendSuccess(embed)
+        } else if (!subcommand || subcommand === "add") {
+            if (!body)
+                return message.channel.sendError("You must specify the note's body!")
+
+            if (note) {
+                const tip = body.length <= 1024 ? " (Overwrite it with `note edit`)" : ""
+                note.body += `\n${body}`
+                if (note.body.length > 1024)
+                    return message.channel.sendError(
+                        `Appending to this note would exceed the character limit!${tip}.`
+                    )
+                await note.save()
+                await message.channel.sendSuccess(`Updated ${user}'s notes!`)
+            } else {
+                const newNote = new ModerationNote()
+                newNote.member = user.id
+                newNote.body = body
+                newNote.updaters = [message.author.id]
+                await newNote.save()
+                await message.channel.sendSuccess(`Created ${user}'s notes!`)
+            }
+        } else if (subcommand === "edit") {
+            if (!note) {
+                return message.channel.sendError(
+                    `${user} doesn't have any notes! (Add them with \`${client.config.prefix} note add\`)`
+                )
+            }
+            note.body = body
+            await note.save()
+            await message.channel.sendSuccess(`Updated ${user}'s notes!`)
+        } else if (subcommand === "clear") {
+            await note.remove()
+            await message.channel.sendSuccess(`Cleared ${user}'s notes!`)
+        }
+    }
+})

--- a/src/commands/notes.ts
+++ b/src/commands/notes.ts
@@ -79,11 +79,11 @@ export default new Command({
                 return message.channel.sendError("You must specify the note's body!")
 
             if (note) {
-                const tip = body.length <= 1024 ? " (Overwrite it with `note edit`)" : ""
+                const tip = body.length <= 1024 ? " (Overwrite it with `note edit`)." : ""
                 note.body += `\n${body}`
                 if (note.body.length > 1024)
                     return message.channel.sendError(
-                        `Appending to this note would exceed the character limit!${tip}.`
+                        `Appending to this note would exceed the character limit!${tip}`
                     )
                 await note.save()
                 await message.channel.sendSuccess(`Updated ${user}'s notes!`)
@@ -98,7 +98,7 @@ export default new Command({
         } else if (subcommand === "edit") {
             if (!note) {
                 return message.channel.sendError(
-                    `${user} doesn't have any notes! (Add them with \`${client.config.prefix} note add\`)`
+                    `${user} doesn't have any notes! (Add them with \`${client.config.prefix}note add\`)`
                 )
             }
             note.body = body

--- a/src/entities/ModerationNote.ts
+++ b/src/entities/ModerationNote.ts
@@ -1,0 +1,20 @@
+import { Entity, Column, CreateDateColumn, UpdateDateColumn, BaseEntity } from "typeorm"
+import SnowflakePrimaryColumn from "./decorators/SnowflakePrimaryColumn"
+
+@Entity({ name: "moderation_notes" })
+export default class ModerationNote extends BaseEntity {
+    @SnowflakePrimaryColumn()
+    member: string
+
+    @Column({ length: 1024 })
+    body: string
+
+    @CreateDateColumn({ name: "created_at" })
+    createdAt: Date
+
+    @UpdateDateColumn({ name: "updated_at" })
+    updatedAt: Date
+
+    @Column("simple-array")
+    updaters: string[]
+}

--- a/src/migrations/1608254163012-AddModerationNotes.ts
+++ b/src/migrations/1608254163012-AddModerationNotes.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddModerationNotes1608254163012 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const exists = await queryRunner.hasTable("moderation_notes")
+        if (!exists)
+            await queryRunner.query(`
+CREATE TABLE \`moderation_notes\` (
+    \`member\` varchar(18) NOT NULL,
+    \`body\` varchar(1024) NOT NULL,
+    \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    \`updaters\` text NOT NULL,
+    PRIMARY KEY (\`member\`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+            `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("moderation_notes", true)
+    }
+}


### PR DESCRIPTION
this PR adds:

-   a `ModerationNote` entity
-   an `AddModerationNotes` migration
-   a `notes` command
-   a "Notes" field in the `check` command

with the purpose of giving helpers, moderators, and managers the ability to add, manage, and read moderation notes of members. therefore, it resolves #12.