### PR TITLE
Added language aliases for =language

### DIFF
--- a/src/commands/language.ts
+++ b/src/commands/language.ts
@@ -6,14 +6,32 @@ import Roles from "../util/roles"
 
 const LANGUAGE_ROLES = {
     english: "English",
+    en: "English",
     espanol: "Español",
+    español: "Español",
+    spanish: "Español",
+    es: "Español",
     francais: "Français",
+    français: "Français",
+    french: "Français",
+    fr: "Français",
     deutsch: "Deutsch",
+    german: "Deutsch",
+    de: "Deutsch",
     russian: "Pусский",
+    pусский: "Pусский",
+    ru: "Pусский",
     portuguese: "Português",
+    português: "Português",
+    pt: "Português",
     italian: "Italiana",
+    italiana: "Italiana",
+    it: "Italiana",
     international: "Ø",
-    chinese: "中文"
+    chinese: "中文",
+    中文: "中文",
+    zh: "中文",
+    cn: "中文"
 }
 
 export default new Command({


### PR DESCRIPTION
Just added some more keys for the `LANGUAGE_ROLES` object at **main-bot/src/commands/language.ts:7**
With this, helpers and support can be more flexible with arguments when running `=language`.
~~Catte pls merge <3~~