### PR TITLE
Automatically update vanity URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ modpack: ""
 prefix: ""
 logs: ""
 appeal: ""
+vanity: ""
 
 guilds:
     main: ""

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ This project originated as a complete rewrite of our old bot, an extension of th
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [All Contributors][] specification. Contributions of any kind are welcome!
@@ -87,6 +88,7 @@ Rename the `_config.yml` file to `config.yml` and fill in all of the fields:
 -   **prefix**: The command prefix.
 -   **logs**: The logs channel ID (enclosed in quotes).
 -   **appeal**: The ban appeal message.
+-   **vanity**: The vanity invite code to use when level 3 boosting is reached.
 -   **guilds**: The guild IDs for the main and staff servers:
     -   **main**
     -   **staff**

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -11,6 +11,13 @@ import chalk from "chalk"
 export default async function (this: Client, message: Message): Promise<unknown> {
     if (message.author.bot) return
 
+    const main = message.guild.id === this.config.guilds.main
+    if (main && message.type === "USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3") {
+        await message.guild.setVanityCode(this.config.vanity)
+        this.logger.info(`Set vanity code to ${chalk.hex("#FF73FA")(this.config.vanity)}`)
+        return
+    }
+
     if (message.content.startsWith(this.config.prefix)) {
         const body = message.content.slice(this.config.prefix.length).trim()
         const args = new Args(body, message)

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,9 +1,11 @@
+import chalk from "chalk"
 import TimedPunishment from "../entities/TimedPunishment"
 import Client from "../struct/Client"
+import Guild from "../struct/discord/Guild"
 import TextChannel from "../struct/discord/TextChannel"
 
 export default async function ready(this: Client): Promise<void> {
-    const main = this.guilds.cache.get(this.config.guilds.main)
+    const main = this.guilds.cache.get(this.config.guilds.main) as Guild
     this.user.setActivity(`with ${main.memberCount} users`, { type: "PLAYING" })
 
     const punishments = await TimedPunishment.find()
@@ -19,5 +21,12 @@ export default async function ready(this: Client): Promise<void> {
                 await channel.messages.fetch(messageID).catch(() => null)
             }
         }
+    }
+
+    const currentVanity = await main.fetchVanityData()
+    const outdated = currentVanity?.code !== this.config.vanity
+    if (outdated && main.features.includes("VANITY_URL")) {
+        await main.setVanityCode(this.config.vanity)
+        this.logger.info(`Set vanity code to ${chalk.hex("#FF73FA")(this.config.vanity)}`)
     }
 }

--- a/src/struct/client/ConfigManager.ts
+++ b/src/struct/client/ConfigManager.ts
@@ -21,6 +21,7 @@ export default class ConfigManager implements Config {
     prefix: string
     logs: string
     appeal: string
+    vanity: string
     guilds: GuildCategories
     suggestions: GuildCategories & { discussion: GuildCategories }
     reactionRoles: ReactionRole
@@ -64,6 +65,7 @@ export type Config = {
     prefix: string
     logs: string
     appeal: string
+    vanity: string
     guilds: GuildCategories
     suggestions: GuildCategories & { discussion: GuildCategories }
     reactionRoles: ReactionRole

--- a/src/struct/discord/Guild.ts
+++ b/src/struct/discord/Guild.ts
@@ -14,4 +14,12 @@ export default class Guild extends Discord.Guild {
     member(user: Discord.UserResolvable): GuildMember {
         return <GuildMember>super.member(user)
     }
+
+    async setVanityCode(code: string): Promise<void> {
+        // @ts-ignore
+        await this.client.api
+            // @ts-ignore
+            .guilds(this.id, "vanity-url")
+            .patch({ data: { code }, reason: "Reached level 3 boosting" })
+    }
 }


### PR DESCRIPTION
this PR adds a `vanity` field to the config, and sets it (if the feature is available) on start-up, and when tier 3 boosting is reached. therefore, it resolves #17.