### PR TITLE
Add task assignment

### DIFF
--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -10,7 +10,7 @@ export default new Command({
     description: "Stop the bot.",
     permission: Roles.BOT_DEVELOPER,
     usage: "['bye']",
-    async run(client: Client, message: Message, args: Args) {
+    async run(this: Command, client: Client, message: Message, args: Args) {
         if (!args.consumeIf("bye")) await message.react("👋").catch(() => null)
         process.exit(0)
     }

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -8,8 +8,6 @@ import Command from "../struct/Command"
 import Task, { TaskStatus, VALID_STATUSES } from "../entities/Task"
 import Roles from "../util/roles"
 
-const ID_REGEX = /\d{18}/g
-
 export default new Command({
     name: "tasks",
     aliases: ["task"],
@@ -44,7 +42,8 @@ export default new Command({
 
         if (subcommand === "add" || !subcommand) {
             args.separator = "|"
-            const assignees = (args.consumeIf(ID_REGEX) || "").match(ID_REGEX)
+            const regex = /\d{18}/g
+            const assignees = (args.consumeIf(regex) || "").match(regex)
             const [title, description] = args.consume(2)
             const status = args.consume().toLowerCase() || null
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -19,10 +19,15 @@ export default new Command({
             name: "add",
             description: "Create a task.",
             usage: "[assignees] | <title> | <description> | [status]"
+        },
+        {
+            name: "status",
+            description: "Change the status of a task.",
+            usage: "<task> <status>"
         }
     ],
     async run(client: Client, message: Message, args: Args) {
-        const subcommand = args.consumeIf(["add"])
+        const subcommand = args.consumeIf(["add", "status"])
 
         if (subcommand === "add" || !subcommand) {
             args.separator = "|"
@@ -30,19 +35,14 @@ export default new Command({
             const [title, description] = args.consume(2)
             const status = args.consume().toLowerCase() || null
 
+            let error: string
             if (title.length > 99)
-                return message.channel.sendError(
-                    "That title is too long! (max. 99 characters)."
-                )
+                error = "The task's title is too long! (max. 99 characters)."
             if (!title || !description)
-                return message.channel.sendError(
-                    "You must provide a title and a description!"
-                )
-            if (status && !VALID_STATUSES.includes(status)) {
-                return message.channel.sendError(
-                    `That's not a valid status! (\`${VALID_STATUSES.join("`, `")}\`).`
-                )
-            }
+                error = "You must provide a title and a description!"
+            if (status && !VALID_STATUSES.includes(status))
+                error = `That's not a valid status! (\`${VALID_STATUSES.join("`, `")}\`).`
+            if (error) return message.channel.sendError(error)
 
             const task = new Task()
             task.title = title
@@ -54,6 +54,21 @@ export default new Command({
             await message.channel.sendSuccess(
                 `Saved **${Discord.Util.escapeMarkdown(task.title)}**! (**#${task.id}**).`
             )
+        } else if (subcommand === "status") {
+            const id = Number(args.consume())
+            if (Number.isNaN(id))
+                return message.channel.sendError("You must provide a task ID!")
+            const status = args.consume().toLowerCase()
+            if (!VALID_STATUSES.includes(status))
+                return message.channel.sendError(
+                    `That's not a valid status! (\`${VALID_STATUSES.join("`, `")}\`).`
+                )
+
+            const task = await Task.findOne(id)
+            task.status = status as TaskStatus
+            await task.save()
+
+            await message.channel.sendSuccess(`Updated task **#${task.id}**!`)
         }
     }
 })

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -1,0 +1,59 @@
+import Discord from "discord.js"
+import Client from "../struct/Client"
+import Message from "../struct/discord/Message"
+import Args from "../struct/Args"
+import Command from "../struct/Command"
+import Task, { TaskStatus, VALID_STATUSES } from "../entities/Task"
+import Roles from "../util/roles"
+
+const ID_REGEX = /\d{18}/g
+
+export default new Command({
+    name: "tasks",
+    aliases: ["task"],
+    description: "Read and manage tasks.",
+    permission: Roles.STAFF,
+    usage: "",
+    subcommands: [
+        {
+            name: "add",
+            description: "Create a task.",
+            usage: "[assignees] | <title> | <description> | [status]"
+        }
+    ],
+    async run(client: Client, message: Message, args: Args) {
+        const subcommand = args.consumeIf(["add"])
+
+        if (subcommand === "add" || !subcommand) {
+            args.separator = "|"
+            const assignees = (args.consumeIf(ID_REGEX) || "").match(ID_REGEX)
+            const [title, description] = args.consume(2)
+            const status = args.consume().toLowerCase() || null
+
+            if (title.length > 99)
+                return message.channel.sendError(
+                    "That title is too long! (max. 99 characters)."
+                )
+            if (!title || !description)
+                return message.channel.sendError(
+                    "You must provide a title and a description!"
+                )
+            if (status && !VALID_STATUSES.includes(status)) {
+                return message.channel.sendError(
+                    `That's not a valid status! (\`${VALID_STATUSES.join("`, `")}\`).`
+                )
+            }
+
+            const task = new Task()
+            task.title = title
+            task.description = description
+            task.assignees = Array.from(assignees || [message.author.id])
+            task.status = status as TaskStatus
+            await task.save()
+
+            await message.channel.sendSuccess(
+                `Saved **${Discord.Util.escapeMarkdown(task.title)}**! (**#${task.id}**).`
+            )
+        }
+    }
+})

--- a/src/entities/Task.ts
+++ b/src/entities/Task.ts
@@ -1,0 +1,21 @@
+import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from "typeorm"
+
+export type TaskStatus = "in-progress" | "abandoned" | "done" | "reported" | "hidden"
+
+@Entity({ name: "tasks" })
+export default class Task extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @Column({ length: 2048 })
+    description: string
+
+    @Column("simple-array")
+    assignees: string[]
+
+    @Column()
+    status: TaskStatus
+}

--- a/src/entities/Task.ts
+++ b/src/entities/Task.ts
@@ -17,6 +17,6 @@ export default class Task extends BaseEntity {
     @Column("simple-array")
     assignees: string[]
 
-    @Column()
-    status: TaskStatus
+    @Column({ nullable: true })
+    status?: TaskStatus
 }

--- a/src/entities/Task.ts
+++ b/src/entities/Task.ts
@@ -1,5 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from "typeorm"
 
+export const VALID_STATUSES = ["in-progress", "abandoned", "done", "reported", "hidden"]
 export type TaskStatus = "in-progress" | "abandoned" | "done" | "reported" | "hidden"
 
 @Entity({ name: "tasks" })

--- a/src/entities/Task.ts
+++ b/src/entities/Task.ts
@@ -1,4 +1,5 @@
 import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from "typeorm"
+import SnowflakeColumn from "./decorators/SnowflakeColumn"
 
 export const VALID_STATUSES = ["in-progress", "abandoned", "done", "reported", "hidden"]
 export type TaskStatus = "in-progress" | "abandoned" | "done" | "reported" | "hidden"
@@ -13,6 +14,9 @@ export default class Task extends BaseEntity {
 
     @Column({ length: 2048 })
     description: string
+
+    @SnowflakeColumn()
+    creator: string
 
     @Column("simple-array")
     assignees: string[]

--- a/src/entities/operators/Includes.ts
+++ b/src/entities/operators/Includes.ts
@@ -1,0 +1,5 @@
+import { FindOperator, Like } from "typeorm"
+
+export default function Includes(value: string): FindOperator<string> {
+    return Like(`%${value}%`)
+}

--- a/src/migrations/1608523298876-AddTasks.ts
+++ b/src/migrations/1608523298876-AddTasks.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class AddTasks1608523298876 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const exists = await queryRunner.hasTable("tasks")
+        if (!exists)
+            await queryRunner.query(`
+CREATE TABLE \`tasks\` (
+    \`id\` int NOT NULL AUTO_INCREMENT,
+    \`title\` varchar(255) NOT NULL,
+    \`description\` varchar(2048) NOT NULL,
+    \`assignees\` text NOT NULL,
+    \`status\` varchar(255) DEFAULT NULL,
+    \`creator\` varchar(18) NOT NULL,
+    PRIMARY KEY (\`id\`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("tasks", true)
+    }
+}


### PR DESCRIPTION
this PR adds:

-   a `Task` entity;
-   a custom `Includes()` operator;
-   an `AddTasks` database migration;
-   a `task` command, with the `add`, `status`,  `list`, and `report` subcommands,

with the purpose of automating weekly management reports. it resolves #7.