### PR TITLE
Distinguish Chinese writing systems

### DIFF
--- a/src/commands/snippets.ts
+++ b/src/commands/snippets.ts
@@ -4,7 +4,7 @@ import Args from "../struct/Args"
 import Command from "../struct/Command"
 import Snippet from "../entities/Snippet"
 import Roles from "../util/roles"
-import languages from "iso-639-1"
+import languages from "../util/patchedISO6391"
 
 export default new Command({
     name: "snippets",

--- a/src/entities/Snippet.ts
+++ b/src/entities/Snippet.ts
@@ -1,7 +1,7 @@
 import { Entity, Column, PrimaryGeneratedColumn, BaseEntity } from "typeorm"
 import Discord from "discord.js"
 import Client from "../struct/Client"
-import languages from "iso-639-1"
+import languages from "../util/patchedISO6391"
 
 @Entity({ name: "snippets" })
 export default class Snippet extends BaseEntity {

--- a/src/entities/Snippet.ts
+++ b/src/entities/Snippet.ts
@@ -11,7 +11,7 @@ export default class Snippet extends BaseEntity {
     @Column({ length: 32 })
     name: string
 
-    @Column({ length: 2 })
+    @Column({ length: 4 })
     language: string
 
     @Column({ length: 2000 })

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -31,7 +31,7 @@ export default async function (this: Client, message: Message): Promise<unknown>
             const language = languages.validate(firstArg) ? firstArg.toLowerCase() : "en"
             const snippet = await Snippet.findOne({ name: commandName, language })
 
-            if (language === "zh")
+            if (firstArg.toLowerCase() === "zh")
                 return message.channel.sendError(
                     `Please choose \`zh-s\` (简体中文) or \`zh-t\` (繁體中文)!`
                 )

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -4,7 +4,7 @@ import Message from "../struct/discord/Message"
 import Args from "../struct/Args"
 import Role from "../struct/discord/Role"
 import Snippet from "../entities/Snippet"
-import languages from "iso-639-1"
+import languages from "../util/patchedISO6391"
 import Roles from "../util/roles"
 import chalk from "chalk"
 

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -27,15 +27,16 @@ export default async function (this: Client, message: Message): Promise<unknown>
         const command = this.commands.search(commandName)
         if (!command) {
             const firstArg = args.consume().toLowerCase()
-            const languageName = languages.getName(firstArg)
-            const language = languageName ? firstArg.toLowerCase() : "en"
+            const languageName = languages.getName(firstArg) || "English"
+            const language = languages.validate(firstArg) ? firstArg.toLowerCase() : "en"
             const snippet = await Snippet.findOne({ name: commandName, language })
 
             if (!snippet) {
                 const unlocalizedSnippet = await Snippet.findOne({ name: commandName })
                 if (unlocalizedSnippet)
-                    // prettier-ignore
-                    message.channel.sendError(`The **${commandName}** snippet hasn't been translated to ${languageName || "English"} yet.`)
+                    message.channel.sendError(
+                        `The **${commandName}** snippet hasn't been translated to ${languageName} yet.`
+                    )
                 return
             }
 

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -31,6 +31,11 @@ export default async function (this: Client, message: Message): Promise<unknown>
             const language = languages.validate(firstArg) ? firstArg.toLowerCase() : "en"
             const snippet = await Snippet.findOne({ name: commandName, language })
 
+            if (language === "zh")
+                return message.channel.sendError(
+                    `Please choose \`zh-s\` (简体中文) or \`zh-t\` (繁體中文)!`
+                )
+
             if (!snippet) {
                 const unlocalizedSnippet = await Snippet.findOne({ name: commandName })
                 if (unlocalizedSnippet)

--- a/src/migrations/1608934966118-DistinguishChinese.ts
+++ b/src/migrations/1608934966118-DistinguishChinese.ts
@@ -6,7 +6,7 @@ export class DistinguishChinese1608934966118 implements MigrationInterface {
         if (!(await queryRunner.hasTable("snippets"))) return
 
         await queryRunner.query(
-            "ALTER TABLE snippets ALTER COLUMN language VARCHAR(4) NOT NULL"
+            "ALTER TABLE snippets MODIFY COLUMN language VARCHAR(4) NOT NULL"
         )
         await queryRunner.query(
             "UPDATE snippets SET language = 'zh-s' WHERE language = 'zh'"
@@ -26,7 +26,7 @@ export class DistinguishChinese1608934966118 implements MigrationInterface {
             "UPDATE snippets SET language = 'cn' WHERE language = 'zh-t'"
         )
         await queryRunner.query(
-            "ALTER TABLE snippets ALTER COLUMN language VARCHAR(2) NOT NULL"
+            "ALTER TABLE snippets MODIFY COLUMN language VARCHAR(2) NOT NULL"
         )
     }
 }

--- a/src/migrations/1608934966118-DistinguishChinese.ts
+++ b/src/migrations/1608934966118-DistinguishChinese.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+// 'zh' and 'cn' were used for simplified and traditional Chinese, respectively
+export class DistinguishChinese1608934966118 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable("snippets"))) return
+
+        await queryRunner.query(
+            "ALTER TABLE snippets ALTER COLUMN language VARCHAR(4) NOT NULL"
+        )
+        await queryRunner.query(
+            "UPDATE snippets SET language = 'zh-s' WHERE language = 'zh'"
+        )
+        await queryRunner.query(
+            "UPDATE snippets SET language = 'zh-t' WHERE language = 'cn'"
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable("snippets"))) return
+
+        await queryRunner.query(
+            "UPDATE snippets SET language = 'zh' WHERE language = 'zh-s'"
+        )
+        await queryRunner.query(
+            "UPDATE snippets SET language = 'cn' WHERE language = 'zh-t'"
+        )
+        await queryRunner.query(
+            "ALTER TABLE snippets ALTER COLUMN language VARCHAR(2) NOT NULL"
+        )
+    }
+}

--- a/src/util/patchedISO6391.ts
+++ b/src/util/patchedISO6391.ts
@@ -1,0 +1,72 @@
+import LANGUAGES_LIST from "iso-639-1/src/data"
+
+delete LANGUAGES_LIST.zh
+Object.assign(LANGUAGES_LIST, {
+    "zh-s": {
+        name: "Simplified Chinese",
+        nativeName: "简体中文"
+    },
+    "zh-t": {
+        name: "Traditional Chinese",
+        nativeName: "繁體中文"
+    }
+})
+
+// this is an extension of ISO 369-1 which adds "zh-s" and "zh-t" (requested by the Translation Team)
+// the code below is copied directly from the iso-639-1 module (with type declarations added).
+export default class ISO6391 {
+    static getLanguages(codes: string[] = []): IndependentLanguageData[] {
+        return codes.map(code => ({
+            code,
+            name: ISO6391.getName(code),
+            nativeName: ISO6391.getNativeName(code)
+        }))
+    }
+
+    static getName(code: string): string {
+        return ISO6391.validate(code) ? LANGUAGES_LIST[code].name : ""
+    }
+
+    static getAllNames(): LanguageData[] {
+        // @ts-ignore
+        return Object.values(LANGUAGES_LIST).map(l => l.name)
+    }
+
+    static getNativeName(code: string): string {
+        return ISO6391.validate(code) ? LANGUAGES_LIST[code].nativeName : ""
+    }
+
+    static getAllNativeNames(): string[] {
+        // @ts-ignore
+        return Object.values(LANGUAGES_LIST).map(l => l.nativeName)
+    }
+
+    static getCode(name: string): string {
+        const code = Object.keys(LANGUAGES_LIST).find(code => {
+            const language = LANGUAGES_LIST[code]
+            return (
+                language.name.toLowerCase() === name.toLowerCase() ||
+                language.nativeName.toLowerCase() === name.toLowerCase()
+            )
+        })
+        return code || ""
+    }
+
+    static getAllCodes(): string[] {
+        return Object.keys(LANGUAGES_LIST)
+    }
+
+    static validate(code: string): boolean {
+        // eslint-disable-next-line no-prototype-builtins
+        return LANGUAGES_LIST.hasOwnProperty(code)
+    }
+}
+
+export interface LanguageData {
+    name: string
+    nativeName: string
+}
+
+export interface IndependentLanguageData extends LanguageData {
+    code: string
+}


### PR DESCRIPTION
this PR:

-   creates a `patchedISO6391` class under `util`, which recognizes the made-up `zh-s` and `zh-t` codes.
-   changes the `language` column of the `Snippet` entity to have a max. length of `4` (to allow storing these language codes).
-   creates a database migration, `DistinguishChinese`, to reflect said change.
-   modifies snippet-dealing user interfaces to use `patchedISO6391`, and warns when trying to use `zh` instead of `zh-s` or `zh-t`.

it resolves #44.