### PR TITLE
Purge command limit, update catte command

### DIFF
--- a/src/commands/catte.ts
+++ b/src/commands/catte.ts
@@ -10,6 +10,6 @@ export default new Command({
     permission: Roles.ANY,
     usage: "",
     async run(this: Command, _client: Client, message: Message) {
-        await message.channel.send("STOP THE CAP")
+        await message.channel.send("the best devs")
     }
 })

--- a/src/commands/catte.ts
+++ b/src/commands/catte.ts
@@ -10,6 +10,6 @@ export default new Command({
     permission: Roles.ANY,
     usage: "",
     async run(this: Command, _client: Client, message: Message) {
-        await message.channel.send("Is the best staff")
+        await message.channel.send("STOP THE CAP")
     }
 })

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -15,6 +15,8 @@ export default new Command({
         const amount = Number(args.consume())
         if (Number.isNaN(amount))
             return message.channel.sendError("You must provide a valid amount!")
+        if(amount > 100)
+            return message.channel.sendError("CATTE IS BEING A TEST")
 
         const purged = await (<TextChannel>message.channel).bulkDelete(amount, true)
         await message.channel.sendSuccess(`Purged ${purged.size} messages.`)


### PR DESCRIPTION
```
import Client from "../struct/Client"
import Message from "../struct/discord/Message"
import Args from "../struct/Args"
import Command from "../struct/Command"
import Roles from "../util/roles"
import TextChannel from "../struct/discord/TextChannel"

export default new Command({
    name: "purge",
    aliases: ["prune", "bulkdelete"],
    description: "Bulk-delete messages in a channel.",
    permission: [Roles.MODERATOR, Roles.MANAGER],
    usage: "<amount>",
    async run(this: Command, client: Client, message: Message, args: Args) {
        const amount = Number(args.consume())
        if (Number.isNaN(amount))
            return message.channel.sendError("You must provide a valid amount!")
        if(amount > 100)
            return message.channel.sendError("CATTE IS BEING A TEST")

        const purged = await (<TextChannel>message.channel).bulkDelete(amount, true)
        await message.channel.sendSuccess(`Purged ${purged.size} messages.`)
        await client.log({
            color: client.config.colors.info,
            author: { name: "Purge" },
            description: `${purged.size} messages purged by ${message.author} in ${message.channel}.`
        })
    }
})
```