### PR TITLE
Make it so I can send messages in the suggestion channel

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ suggestions:
     discussion:
         main: ""
         staff: ""
+suggestionMgrID: ""
 suggestionOffset:
     main: 0
     staff: 0

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -70,13 +70,14 @@ export default async function (this: Client, message: Message): Promise<unknown>
 
     const suggestions = Object.values(this.config.suggestions)
     if (suggestions.includes(message.channel.id)) {
-        const error = await message.channel.sendError(
-            `Please use the \`suggest\` command to post suggestions! (Check \`${this.config.prefix}help suggest\` for help). **Your message will be deleted in 30 seconds.**`
-        )
-
-        await message.delete({ timeout: 30000 })
-        await error.delete({ timeout: 30000 })
-        return
+        if (message.author.id !== "369661965376946176") {
+            const error = await message.channel.sendError(
+                `Please use the \`suggest\` command to post suggestions! (Check \`${this.config.prefix}help suggest\` for help). **Your message will be deleted in 30 seconds.**`
+            )
+            await message.delete({ timeout: 30000 })
+            await error.delete({ timeout: 30000 })
+            return
+        }
     }
 
     if (message.content === "donde es server")

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -70,14 +70,13 @@ export default async function (this: Client, message: Message): Promise<unknown>
 
     const suggestions = Object.values(this.config.suggestions)
     if (suggestions.includes(message.channel.id)) {
-        if (message.author.id !== "369661965376946176") {
-            const error = await message.channel.sendError(
-                `Please use the \`suggest\` command to post suggestions! (Check \`${this.config.prefix}help suggest\` for help). **Your message will be deleted in 30 seconds.**`
-            )
-            await message.delete({ timeout: 30000 })
-            await error.delete({ timeout: 30000 })
-            return
-        }
+        if (message.author.id == this.config.suggestionMgrID) return
+        const error = await message.channel.sendError(
+            `Please use the \`suggest\` command to post suggestions! (Check \`${this.config.prefix}help suggest\` for help). **Your message will be deleted in 30 seconds.**`
+        )
+        await message.delete({ timeout: 30000 })
+        await error.delete({ timeout: 30000 })
+        return
     }
 
     if (message.content === "donde es server")


### PR DESCRIPTION
This Pull request makes it so I (The suggestion manager) can send messages in the suggestions channel without it getting deleted, for future announcements, guidelines, or rules in the channel.