### PR TITLE
Reminders

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -15,11 +15,13 @@ export default new Command({
     usage: "[command]",
     dms: true,
     async run(this: Command, client: Client, message: Message, args: Args) {
-        const member = (message.guild
-            ? message.member
-            : await client.guilds.main.members
-                  .fetch({ user: message.author, cache: true })
-                  .catch(() => null)) as GuildMember
+        const member = (
+            message.guild
+                ? message.member
+                : await client.guilds.main.members
+                      .fetch({ user: message.author, cache: true })
+                      .catch(() => null)
+        ) as GuildMember
         const commandName = args.consume()
 
         if (commandName) {

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -73,6 +73,12 @@ export default new Command({
                 case "weekly":
                     millis =  1000*60*60*24*7 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 7 days)
                     break;
+                case "bi-weekly":
+                    millis =  1000*60*60*24*3.5 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 3.5 days)
+                    break
+                case "monthly":
+                    millis = 1000*60*60*24*30 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 30 days)
+                    break
                 default:
                     return message.channel.sendError("Invalid time length !")
             }

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -39,8 +39,7 @@ export default new Command({
             const tidy: Record<string, { channel: string; message: string }> = {}
 
             for (const reminder of reminders) {
-                if (!tidy[reminder.id])
-                    tidy[reminder.id] = { channel: "", message: "" }
+                if (!tidy[reminder.id]) tidy[reminder.id] = { channel: "", message: "" }
 
                 tidy[reminder.id].channel = reminder.channel
                 tidy[reminder.id].message = reminder.message
@@ -55,39 +54,39 @@ export default new Command({
                 author: { name: "Reminder list" },
                 description: list
             })
-            
         }
 
         if (subcommand === "add") {
             const channel = await args.consumeChannel()
-            if(!channel){
-                return message.channel.sendError("no channel found");
+            if (!channel) {
+                return message.channel.sendError("no channel found")
             }
 
             const time = args.consume().toLowerCase()
-            let millis;
-            switch(time) {
+            let millis
+            switch (time) {
                 case "test":
-                    millis = 1000*5 // 5 seconds
+                    millis = 1000 * 5 // 5 seconds
                     break
                 case "weekly":
-                    millis =  1000*60*60*24*7 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 7 days)
-                    break;
+                    millis = 1000 * 60 * 60 * 24 * 7 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 7 days)
+                    break
                 case "bi-weekly":
-                    millis =  1000*60*60*24*3.5 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 3.5 days)
+                    millis = 1000 * 60 * 60 * 24 * 3.5 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 3.5 days)
                     break
                 case "monthly":
-                    millis = 1000*60*60*24*30 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 30 days)
+                    millis = 1000 * 60 * 60 * 24 * 30 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 30 days)
                     break
                 case "bi-monthly":
-                    millis = 1000*60*60*24*15 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 15 days)
+                    millis = 1000 * 60 * 60 * 24 * 15 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 15 days)
                     break
                 default:
                     return message.channel.sendError("Invalid time length !")
             }
 
             const body = args.consumeRest()
-            if (!body) return message.channel.sendError("You must specify a reminder message.")
+            if (!body)
+                return message.channel.sendError("You must specify a reminder message.")
 
             const reminder = new Reminder()
             reminder.channel = channel.id
@@ -101,15 +100,17 @@ export default new Command({
 
         const id = parseInt(args.consume())
         if (!id) return message.channel.sendError("You must specify an id!")
-        
+
         const reminder = await Reminder.findOne(id)
 
         if (subcommand === "delete") {
-            if(!reminder) return message.channel.sendError("That reminder doesn't exist!")
+            if (!reminder)
+                return message.channel.sendError("That reminder doesn't exist!")
             await reminder.delete()
             return message.channel.sendSuccess(`Reminder ${id} deleted!`)
         } else if (subcommand === "edit") {
-            if(!reminder) return message.channel.sendError("That reminder doesn't exist!")
+            if (!reminder)
+                return message.channel.sendError("That reminder doesn't exist!")
             const body = args.consumeRest()
             reminder.message = body
             await reminder.save()

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -1,0 +1,108 @@
+import Client from "../struct/Client"
+import Message from "../struct/discord/Message"
+import Args from "../struct/Args"
+import Command from "../struct/Command"
+import Roles from "../util/roles"
+import Reminder from "../entities/Reminder"
+
+export default new Command({
+    name: "remind",
+    aliases: [],
+    description: "List and manage reminders.",
+    permission: [Roles.MANAGER],
+    usage: "",
+    subcommands: [
+        {
+            name: "add",
+            description: "Add a reminder.",
+            permission: [Roles.MANAGER],
+            usage: "<channel> <interval> <message>"
+        },
+        {
+            name: "edit",
+            description: "Edit a reminder.",
+            permission: [Roles.MANAGER],
+            usage: "<id> <message>"
+        },
+        {
+            name: "delete",
+            description: "Delete a reminder.",
+            permission: [Roles.MANAGER],
+            usage: "<id>"
+        }
+    ],
+    async run(this: Command, client: Client, message: Message, args: Args) {
+        const subcommand = args.consume().toLowerCase()
+
+        if (subcommand === "list" || !subcommand) {
+            const reminders = await Reminder.find()
+            const tidy: Record<string, { channel: string; message: string }> = {}
+
+            for (const reminder of reminders) {
+                if(reminder.cancelled) continue;
+                if (!tidy[reminder.id])
+                    tidy[reminder.id] = { channel: "", message: "" }
+
+                tidy[reminder.id].channel = reminder.channel
+                tidy[reminder.id].message = reminder.message
+            }
+
+            let list = ""
+            for (const [id, { channel, message }] of Object.entries(tidy)) {
+                list += `${id}: \u200B \u200B <#${channel}> - ${message}\n`
+            }
+
+            return message.channel.sendSuccess({
+                author: { name: "Reminder list" },
+                description: list
+            })
+            
+        }
+
+        if (subcommand === "add") {
+            const channel = await args.consumeChannel()
+            if(!channel){
+                return message.channel.sendError("no channel found");
+            }
+
+            const time = args.consume().toLowerCase()
+            let millis;
+            switch(time) {
+                case "test":
+                    millis = 1000*5 // 5 seconds
+                    break
+                case "weekly":
+                    millis =  1000*60*60*24*7 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 7 days)
+                    break;
+                default:
+                    return message.channel.sendError("Invalid time length !")
+            }
+
+            const body = args.consumeRest()
+            if (!body) return message.channel.sendError("You must specify a reminder message.")
+
+            const reminder = new Reminder()
+            reminder.channel = channel.id
+            reminder.interval = millis
+            reminder.message = body
+            await reminder.save()
+            reminder.schedule(client)
+
+            return message.channel.sendSuccess(`Scheduled reminder for ${channel}!`)
+        }
+
+        const id = parseInt(args.consume())
+        if (!id) return message.channel.sendError("You must specify an id!")
+        
+        const reminder = await Reminder.findOne(id)
+
+        if (subcommand === "delete") {
+            if(!reminder) return message.channel.sendError("that reminder doesn't exist!")
+            reminder.cancelled = true
+            await reminder.save()
+            return message.channel.sendSuccess(`Reminder ${id} deleted!`)
+        } else if (subcommand === "edit") {
+            console.log("edit")
+        }
+    }
+})

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -51,7 +51,7 @@ export default new Command({
 
             let list = ""
             for (const [id, { channel, message, end }] of Object.entries(tidy)) {
-                list += `${id}: \u200B \u200B <#${channel}> (next reminder ${formatTimestamp(end, "R")}) - ${message}\n`
+                list += `**#$id:** <#${channel}> (next ${formatTimestamp(end, "R")}) — ${message}\n`
             }
 
             return message.channel.sendSuccess({
@@ -85,7 +85,7 @@ export default new Command({
                     millis = 1000 * 60 * 60 * 24 * 15 // half a month (1000ms * 60s * 60m * 24h * 15d)
                     break
                 default:
-                    return message.channel.sendError("Invalid time length !")
+                    return message.channel.sendError("Invalid time length!")
             }
 
             const body = args.consumeRest()
@@ -103,7 +103,7 @@ export default new Command({
         }
 
         const id = parseInt(args.consume())
-        if (!id) return message.channel.sendError("You must specify an id!")
+        if (!id) return message.channel.sendError("You must specify an ID!")
 
         const reminder = await Reminder.findOne(id)
 
@@ -111,14 +111,14 @@ export default new Command({
             if (!reminder)
                 return message.channel.sendError("That reminder doesn't exist!")
             await reminder.delete()
-            return message.channel.sendSuccess(`Reminder ${id} deleted!`)
+            return message.channel.sendSuccess(`Reminder **#${id}** deleted!`)
         } else if (subcommand === "edit") {
             if (!reminder)
                 return message.channel.sendError("That reminder doesn't exist!")
             const body = args.consumeRest()
             reminder.message = body
             await reminder.save()
-            return message.channel.sendSuccess(`Set reminder ${id}'s message to ${body}`)
+            return message.channel.sendSuccess(`Set the message of reminder **#${id}** to:\n>>>${body}`)
         }
     }
 })

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -51,7 +51,10 @@ export default new Command({
 
             let list = ""
             for (const [id, { channel, message, end }] of Object.entries(tidy)) {
-                list += `**#$id:** <#${channel}> (next ${formatTimestamp(end, "R")}) — ${message}\n`
+                list += `**#$id:** <#${channel}> (next ${formatTimestamp(
+                    end,
+                    "R"
+                )}) — ${message}\n`
             }
 
             return message.channel.sendSuccess({
@@ -118,7 +121,9 @@ export default new Command({
             const body = args.consumeRest()
             reminder.message = body
             await reminder.save()
-            return message.channel.sendSuccess(`Set the message of reminder **#${id}** to:\n>>>${body}`)
+            return message.channel.sendSuccess(
+                `Set the message of reminder **#${id}** to:\n>>>${body}`
+            )
         }
     }
 })

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -65,7 +65,7 @@ export default new Command({
         if (subcommand === "add") {
             const channel = await args.consumeChannel()
             if (!channel) {
-                return message.channel.sendError("no channel found")
+                return message.channel.sendError("You must provide a channel!")
             }
 
             const time = args.consume().toLowerCase()

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -73,16 +73,16 @@ export default new Command({
                     millis = 1000 * 5
                     break
                 case "weekly":
-                    millis = 1000 * 60 * 60 * 24 * 7 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 7 days)
+                    millis = 1000 * 60 * 60 * 24 * 7 // 1 week (1000ms * 60s * 60m * 24h * 7d)
                     break
                 case "bi-weekly":
-                    millis = 1000 * 60 * 60 * 24 * 3.5 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 3.5 days)
+                    millis = 1000 * 60 * 60 * 24 * 3.5 // half a week (1000ms * 60s * 60m * 24h * 3.5d)
                     break
                 case "monthly":
-                    millis = 1000 * 60 * 60 * 24 * 30 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 30 days)
+                    millis = 1000 * 60 * 60 * 24 * 30 // 1 month (1000ms * 60s * 60m * 24h * 30d)
                     break
                 case "bi-monthly":
-                    millis = 1000 * 60 * 60 * 24 * 15 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 15 days)
+                    millis = 1000 * 60 * 60 * 24 * 15 // half a month (1000ms * 60s * 60m * 24h * 15d)
                     break
                 default:
                     return message.channel.sendError("Invalid time length !")

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -39,7 +39,6 @@ export default new Command({
             const tidy: Record<string, { channel: string; message: string }> = {}
 
             for (const reminder of reminders) {
-                // if(reminder.cancelled) continue;
                 if (!tidy[reminder.id])
                     tidy[reminder.id] = { channel: "", message: "" }
 

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -79,6 +79,9 @@ export default new Command({
                 case "monthly":
                     millis = 1000*60*60*24*30 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 30 days)
                     break
+                case "bi-monthly":
+                    millis = 1000*60*60*24*15 // 30 days (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 15 days)
+                    break
                 default:
                     return message.channel.sendError("Invalid time length !")
             }

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -4,7 +4,7 @@ import Args from "../struct/Args"
 import Command from "../struct/Command"
 import Roles from "../util/roles"
 import Reminder from "../entities/Reminder"
-import formatUTCDate from "../util/formatUTCDate"
+import formatTimestamp from "../util/formatTimestamp"
 
 export default new Command({
     name: "remind",
@@ -51,9 +51,7 @@ export default new Command({
 
             let list = ""
             for (const [id, { channel, message, end }] of Object.entries(tidy)) {
-                list += `${id}: \u200B \u200B <#${channel}> (next reminder at ${formatUTCDate(
-                    end
-                )}) - ${message}\n`
+                list += `${id}: \u200B \u200B <#${channel}> (next reminder ${formatTimestamp(end, "R")}) - ${message}\n`
             }
 
             return message.channel.sendSuccess({

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -65,9 +65,6 @@ export default new Command({
             const time = args.consume().toLowerCase()
             let millis
             switch (time) {
-                case "test":
-                    millis = 1000 * 5 // 5 seconds
-                    break
                 case "weekly":
                     millis = 1000 * 60 * 60 * 24 * 7 // 1 week (1000 milliseconds * 60 seconds * 60 minutes * 24 hours * 7 days)
                     break

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -39,7 +39,7 @@ export default new Command({
             const tidy: Record<string, { channel: string; message: string }> = {}
 
             for (const reminder of reminders) {
-                if(reminder.cancelled) continue;
+                // if(reminder.cancelled) continue;
                 if (!tidy[reminder.id])
                     tidy[reminder.id] = { channel: "", message: "" }
 
@@ -97,9 +97,8 @@ export default new Command({
         const reminder = await Reminder.findOne(id)
 
         if (subcommand === "delete") {
-            if(!reminder) return message.channel.sendError("that reminder doesn't exist!")
-            reminder.cancelled = true
-            await reminder.save()
+            if(!reminder) return message.channel.sendError("That reminder doesn't exist!")
+            await reminder.delete()
             return message.channel.sendSuccess(`Reminder ${id} deleted!`)
         } else if (subcommand === "edit") {
             console.log("edit")

--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -100,7 +100,11 @@ export default new Command({
             await reminder.delete()
             return message.channel.sendSuccess(`Reminder ${id} deleted!`)
         } else if (subcommand === "edit") {
-            console.log("edit")
+            if(!reminder) return message.channel.sendError("That reminder doesn't exist!")
+            const body = args.consumeRest()
+            reminder.message = body
+            await reminder.save()
+            return message.channel.sendSuccess(`Set reminder ${id}'s message to ${body}`)
         }
     }
 })

--- a/src/commands/snippets.ts
+++ b/src/commands/snippets.ts
@@ -137,7 +137,9 @@ export default new Command({
 
             if (subcommand === "add") {
                 if (client.commands.search(name))
-                    return message.channel.sendError("That snippet name is already used by a command.")
+                    return message.channel.sendError(
+                        "That snippet name is already used by a command."
+                    )
                 if (existingSnippet)
                     return message.channel.sendError("That snippet already exists!")
                 snippet = new Snippet()

--- a/src/entities/Reminder.ts
+++ b/src/entities/Reminder.ts
@@ -1,0 +1,64 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    BaseEntity,
+    CreateDateColumn
+} from "typeorm"
+import SnowflakeColumn from "./decorators/SnowflakeColumn"
+import Client from "../struct/Client"
+import milliseconds from "./transformers/milliseconds"
+import Discord from "discord.js"
+
+@Entity({ name: "reminders" })
+export default class Reminder extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @SnowflakeColumn()
+    channel: string
+
+    @Column({ length: 1024 })
+    message: string
+
+    @Column({ transformer: milliseconds })
+    interval: number
+
+    @CreateDateColumn({ name: "created_at" })
+    createdAt: Date
+
+    @Column({ default: false })
+    cancelled: boolean
+
+    get end(): Date {
+        return new Date(this.createdAt.getTime() + this.interval)
+    }
+
+    private reminderTimeout: NodeJS.Timeout
+
+    async sendReminder(client: Client): Promise<void> {
+        const channel = client.channels.cache.find(
+            channel =>
+                // @ts-ignore
+                channel.id === this.channel
+        ) as Discord.TextChannel
+        if (!channel) return
+        if(!await (await Reminder.findOne(this.id)).cancelled)
+            channel.send(this.message)
+            this.createdAt = new Date(Date.now())
+            this.schedule(client)
+    }
+
+    schedule(client: Client): void {
+        if (this.interval === 0) return
+        const timeout = this.end.getTime() - Date.now()
+
+        // avoid TimeoutOverflowWarning; reschedule
+        // (2147483647 ms is ~24 days)
+        if (timeout > 2147483647) {
+            this.reminderTimeout = setTimeout(() => this.schedule(client), 2147483647)
+        } else {
+            this.reminderTimeout = setTimeout(() => this.sendReminder(client), timeout)
+        }
+    }
+}

--- a/src/entities/Reminder.ts
+++ b/src/entities/Reminder.ts
@@ -43,10 +43,7 @@ export default class Reminder extends BaseEntity {
                 channel.id === this.channel
         ) as Discord.TextChannel
         if (!channel) return
-        if(!await (await Reminder.findOne(this.id)).cancelled)
-            channel.send(this.message)
-            this.createdAt = new Date(Date.now())
-            this.schedule(client)
+        channel.send(this.message)
     }
 
     schedule(client: Client): void {
@@ -60,5 +57,10 @@ export default class Reminder extends BaseEntity {
         } else {
             this.reminderTimeout = setTimeout(() => this.sendReminder(client), timeout)
         }
+    }
+
+    async delete(): Promise<void> {
+        clearTimeout(this.reminderTimeout)
+        await this.remove()
     }
 }

--- a/src/entities/Reminder.ts
+++ b/src/entities/Reminder.ts
@@ -27,9 +27,6 @@ export default class Reminder extends BaseEntity {
     @CreateDateColumn({ name: "created_at" })
     createdAt: Date
 
-    @Column({ default: false })
-    cancelled: boolean
-
     get end(): Date {
         return new Date(this.createdAt.getTime() + this.interval)
     }

--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -60,11 +60,13 @@ export default async function (this: Client, message: Message): Promise<unknown>
             return message.channel.send(snippet.body).catch(() => null)
         }
 
-        const member = (message.guild
-            ? message.member
-            : await mainGuild.members
-                  .fetch({ user: message.author, cache: true })
-                  .catch(() => null)) as GuildMember
+        const member = (
+            message.guild
+                ? message.member
+                : await mainGuild.members
+                      .fetch({ user: message.author, cache: true })
+                      .catch(() => null)
+        ) as GuildMember
 
         const hasPermission = member && member.hasRole(command.permission)
         if (message.channel.type === "dm" && !command.dms) return

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -5,6 +5,7 @@ import AdvancedBuilder from "../entities/AdvancedBuilder"
 import Client from "../struct/Client"
 import TextChannel from "../struct/discord/TextChannel"
 import noop from "../util/noop"
+import Reminder from "../entities/Reminder"
 
 export default async function ready(this: Client): Promise<void> {
     const activity = `with ${this.guilds.main.memberCount} users`
@@ -14,6 +15,7 @@ export default async function ready(this: Client): Promise<void> {
     BannerImage.schedule(this)
     for (const punishment of await TimedPunishment.find()) punishment.schedule(this)
     for (const builder of await AdvancedBuilder.find()) builder.schedule(this)
+    for (const reminder of await Reminder.find()) reminder.schedule(this)
 
     // cache reaction role messages
     for (const channelID of Object.keys(this.config.reactionRoles)) {

--- a/src/migrations/1624421039931-AddReminders.ts
+++ b/src/migrations/1624421039931-AddReminders.ts
@@ -1,0 +1,25 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddReminders1624421039931 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const exists = await queryRunner.hasTable("reminders")
+        if (!exists)
+            await queryRunner.query(`
+            CREATE TABLE \`reminders\` (
+                \`id\` int(11) NOT NULL AUTO_INCREMENT,
+                \`channel\` varchar(18) NOT NULL,
+                \`message\` varchar(1024) NOT NULL,
+                \`interval\` int(11) NOT NULL,
+                \`created_at\` datetime(6) NOT NULL DEFAULT current_timestamp(6),
+                \`cancelled\` tinyint(4) NOT NULL DEFAULT 0,
+                PRIMARY KEY (\`id\`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("reminders", true)
+    }
+
+}

--- a/src/migrations/1624421039931-AddReminders.ts
+++ b/src/migrations/1624421039931-AddReminders.ts
@@ -1,7 +1,6 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from "typeorm"
 
 export class AddReminders1624421039931 implements MigrationInterface {
-
     public async up(queryRunner: QueryRunner): Promise<void> {
         const exists = await queryRunner.hasTable("reminders")
         if (!exists)
@@ -21,5 +20,4 @@ export class AddReminders1624421039931 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.dropTable("reminders", true)
     }
-
 }


### PR DESCRIPTION
this pr adds a reminder system that allows for creating, editing, and deleting reminders for specific channels
includes:
- `Reminder` entity to store reminders, including the message, channel id, and interval
- a reminder command with `add`, `delete`, `edit`, and `list` subcommands

gonna mark this as draft until xylo approves