### PR TITLE
A fix that literally adds 2 chars that allows file extensions to be in caps

### DIFF
--- a/src/struct/Args.ts
+++ b/src/struct/Args.ts
@@ -158,7 +158,7 @@ export default class Args {
         if (attachment) return attachment.url
 
         const url = this.consumeIf(/https?:\/\/(.+)?\.(jpe?g|png|gif)/i)
-        if (url) return url
+        if (url) return url.replace(/.(jpe?g|png|gif)/i, url.match(/.(jpe?g|png|gif)/i)[0].toLowerCase())
 
         return null
     }


### PR DESCRIPTION


Seemingly not being able to use file extensions with caps has been a small extra hassle for the mod team which this very shit simple fix fixes.