### PR TITLE
feat(suggestion): add 'open' status to suggestion status cmd

### DIFF
--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -111,7 +111,8 @@ export default new Command({
                         "forwarded",
                         "in-progress",
                         "information",
-                        "invalid"
+                        "invalid",
+                        "open"
                     ]
                 },
                 {
@@ -459,7 +460,7 @@ export default new Command({
             if (thread?.locked && !thread?.archived) await thread.setLocked(false)
 
             const CLOSE_STATUS = ["approved", "denied", "duplicate", "invalid"]
-            const OPEN_STATUS = ["forwarded", "in-progress", "information"]
+            const OPEN_STATUS = ["open", "forwarded", "in-progress", "information"]
             if (
                 // prettier-ignore
                 thread && (( // thread must stay outside parentheses

--- a/src/entities/Suggestion.entity.ts
+++ b/src/entities/Suggestion.entity.ts
@@ -21,7 +21,8 @@ export enum SuggestionStatuses {
     "forwarded",
     "in-progress",
     "information",
-    "invalid"
+    "invalid",
+    "open"
 }
 
 export interface Identifier {


### PR DESCRIPTION
This is mainly needed because i false closed some suggestions and these doesn't have another status. It's also a helpful addition going forward.

I have not seen a easy way to test it and the changes should be pretty safe.