### PR TITLE
fix(suggestion): Add open status to suggestionStatusActions

### DIFF
--- a/config/extensions/suggestionStatusActions.json5
+++ b/config/extensions/suggestionStatusActions.json5
@@ -5,5 +5,6 @@
     "forwarded": "Forwarded to the respective team",
     "in-progress": "Marked as in progress",
     "information": "Marked as needing more information",
-    "invalid": "Invalidated"
+    "invalid": "Invalidated",
+    "open": "Re-opened"
 }


### PR DESCRIPTION
Else when you try to reopen a suggestion you get an error: You must specify a new suggestion status! (approved, denied, duplicate, forwarded, in-progress, information, or invalid)